### PR TITLE
Atualiza o tlmgr sob demanda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 # Documentação: https://github.com/abntex/limarka/wiki/Limarka-com-Docker
 
 FROM limarka/limarka:latest
+RUN wget -O /update.sh http://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.sh
+RUN chmod +x /update.sh
+RUN /update.sh
 RUN  tlmgr update --self
 
 # Adicione os pacotes que precisa instalar nessa imagem customizada:


### PR DESCRIPTION
Este commit atualiza o `tlmgr` sob demanda através do script bash disponível pelo mantenedor do mesmo.

A chave PGP do repositório expira todo ano, ou seja, a não ser que a imagem base tenha atualizado o `tlmgr` no último ano, usuários não poderão fazer build da imagem Docker pois o `tlmgr update --self` retorna:

```
/root/bin/tlmgr: unexpected return value from verify_checksum: -5
```

Fonte: https://tex.stackexchange.com/a/528635